### PR TITLE
vimhelp: Strip \x01ACTION…\x01 off msg

### DIFF
--- a/plugins/vimhelp.awk
+++ b/plugins/vimhelp.awk
@@ -15,6 +15,11 @@
 	# get key from msg, defaulting to no key (i.e. just ":help")
 	$0 = msg
 	key = ""
+	# Turn an ACTION (/me) into a normal message
+	if ($0 ~ "\x01""ACTION .*""\x01") {
+		$0 = substr($0, index($0, $2))
+		$0 = substr($0, 1, length($0)-1)
+	}
 	for (i=1; i<NF; i++)
 		if ($i ~ "^;(h|he|hel|help)$" && i != NF)
 			key = $(i+1)


### PR DESCRIPTION
This allows one to do "/me checks ;help bar" and have the message be
properly interpreted.  Previously, the \x01 would be part of the help
topic.
